### PR TITLE
chore: AI-assisted Ruff update fixing and review

### DIFF
--- a/.github/workflows/check_updates.generated.yml
+++ b/.github/workflows/check_updates.generated.yml
@@ -18,7 +18,16 @@ jobs:
           token: '${{ secrets.GH_DPRINTBOT_PAT }}'
       - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.x
       - name: Run script
+        env:
+          OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
+          CODEX_MODEL: gpt-5.6-terra
+          REVIEW_MODEL: gpt-5.6-sol
         run: |-
           git config user.email "dprintbot@users.noreply.github.com"
           git config user.name "dprintbot"

--- a/.github/workflows/check_updates.ts
+++ b/.github/workflows/check_updates.ts
@@ -14,8 +14,23 @@ const buildJob = job("build", {
     },
     { uses: "denoland/setup-deno@v2" },
     { uses: "dsherret/rust-toolchain-file@v1" },
+    // the update script builds the wasm release as one of its checks.
+    {
+      name: "Install wasm32 target",
+      run: "rustup target add wasm32-unknown-unknown",
+    },
+    // node is needed so the update script can install and run the OpenAI
+    // Codex CLI (@openai/codex) when it has to reconcile a Ruff update.
+    { uses: "actions/setup-node@v6", with: { "node-version": "24.x" } },
     {
       name: "Run script",
+      env: {
+        OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+        // model that fixes/wires up the Ruff update (Codex)
+        CODEX_MODEL: "gpt-5.6-terra",
+        // separate model that independently reviews the changes
+        REVIEW_MODEL: "gpt-5.6-sol",
+      },
       run: [
         `git config user.email "dprintbot@users.noreply.github.com"`,
         `git config user.name "dprintbot"`,

--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@david/dax@0.42.0": "0.42.0",
+    "jsr:@david/gagen@0.5": "0.5.1",
     "jsr:@david/path@0.2": "0.2.0",
     "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@std/assert@0.221": "0.221.0",
@@ -14,6 +15,7 @@
     "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/semver@1": "1.0.7",
     "jsr:@std/streams@0.221": "0.221.0",
+    "jsr:@std/yaml@^1.0.11": "1.1.2",
     "npm:octokit@^3.1.0": "3.2.2_@octokit+core@5.2.2"
   },
   "jsr": {
@@ -27,6 +29,12 @@
         "jsr:@std/io",
         "jsr:@std/path@1",
         "jsr:@std/streams"
+      ]
+    },
+    "@david/gagen@0.5.1": {
+      "integrity": "e0f069243e57eac9fb319b40c0061635e50e498f0126aa0d2509cb5209745033",
+      "dependencies": [
+        "jsr:@std/yaml"
       ]
     },
     "@david/path@0.2.0": {
@@ -79,6 +87,9 @@
       "dependencies": [
         "jsr:@std/io"
       ]
+    },
+    "@std/yaml@1.1.2": {
+      "integrity": "de612653c036749ba2044165e316f52412b0f0698afffb7ee80b5331d6d2abae"
     }
   },
   "npm": {

--- a/scripts/ai_fix.ts
+++ b/scripts/ai_fix.ts
@@ -1,0 +1,291 @@
+/**
+ * Reconciles this plugin with a new Ruff release using OpenAI Codex, in two
+ * stages that each run Codex with a different model:
+ *
+ *   1. a Codex agentic session edits the source and runs the checks until they
+ *      pass (fixing breakage and/or wiring up new formatter options), then
+ *   2. a SEPARATE reviewer model reviews the result with Codex, so it can
+ *      investigate (read the upstream ruff source, grep the repo). It is
+ *      instructed to review only and not modify anything. If it finds blocking
+ *      issues they are fed back to the stage-1 Codex for another pass, bounded
+ *      by `REVIEW_MAX_ROUNDS`. If it still isn't approved, this throws so the
+ *      workflow fails and nothing is published.
+ *
+ * Two situations call this:
+ *   - a patch bump that failed the checks (fix the breakage), and
+ *   - any minor bump (review for new/renamed/removed options even when it
+ *     still compiles).
+ *
+ * Codex must NOT commit or push -- `update.ts` captures the working tree
+ * changes into the existing Ruff bump commit afterwards.
+ */
+import { $ } from "automation";
+
+export interface AiFixOptions {
+  /** true for a patch bump, false for a minor/major bump. */
+  isPatchBump: boolean;
+  /** Ruff tag currently in Cargo.toml (before the bump). */
+  fromVersion: string;
+  /** Ruff tag being upgraded to. */
+  toVersion: string;
+  /** Whether the checks (test + clippy + wasm build) already passed. */
+  checksPassed: boolean;
+  /** Combined output of the failing checks (empty when `checksPassed`). */
+  checkOutput: string;
+}
+
+/** Max number of times the reviewer may send changes back to Codex. */
+const REVIEW_MAX_ROUNDS = 2;
+
+export async function aiFixRuffUpdate(options: AiFixOptions): Promise<void> {
+  const apiKey = requireApiKey();
+  await ensureCodexInstalled();
+  await codexLogin(apiKey);
+
+  // stage 1: let Codex reconcile the update.
+  await runCodex(buildFixPrompt(options));
+
+  // stage 2: independent second-model review, with a bounded refix loop.
+  for (let round = 1;; round++) {
+    const review = await reviewChanges(options);
+    logReview(review);
+    if (review.approved) {
+      return;
+    }
+    if (round > REVIEW_MAX_ROUNDS) {
+      const blocking = review.issues.filter((i) => i.severity === "blocking");
+      throw new Error(
+        `AI reviewer did not approve after ${REVIEW_MAX_ROUNDS} refix round(s). Blocking issues:\n` +
+          blocking.map((i) => `  - ${i.description}`).join("\n"),
+      );
+    }
+    $.logStep(`Reviewer requested changes — Codex refix round ${round}...`);
+    await runCodex(buildRefixPrompt(review));
+  }
+}
+
+// stage 1: Codex ---------------------------------------------------------------
+
+async function runCodex(prompt: string): Promise<void> {
+  const args = ["exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"];
+  const model = Deno.env.get("CODEX_MODEL");
+  if (model) {
+    args.push("--model", model);
+  }
+  args.push(prompt);
+
+  $.logStep("Running Codex...");
+  await $`codex ${args}`;
+}
+
+function buildFixPrompt(options: AiFixOptions): string {
+  const { isPatchBump, fromVersion, toVersion, checksPassed, checkOutput } = options;
+
+  const situation = checksPassed
+    ? `Ruff was upgraded from ${fromVersion} to ${toVersion} (a ${
+      isPatchBump ? "patch" : "minor"
+    } bump). The project already compiles and the checks pass, but a new Ruff version may have ADDED, RENAMED, or REMOVED formatter options that should be surfaced by this plugin.`
+    : `Ruff was upgraded from ${fromVersion} to ${toVersion} and the checks fail (the project no longer builds, or \`cargo test\` or \`cargo clippy\` fails). This is almost always because ruff's formatter API (its \`PyFormatOptions\` builder methods or related option enums) changed.`;
+
+  const failureOutput = checkOutput.trim().length > 0
+    ? [
+      ``,
+      `The checks currently fail with the output below. Use it as your starting point instead of re-running the checks just to rediscover the errors:`,
+      "```",
+      truncateHead(checkOutput.trim()),
+      "```",
+    ]
+    : [];
+
+  return [
+    `You are updating the "dprint-plugin-ruff" Rust crate, a dprint plugin that wraps ruff's Python formatter (\`ruff_python_formatter\`) to format Python.`,
+    ``,
+    situation,
+    ...failureOutput,
+    ``,
+    `Your goal: make the checks pass AND keep this plugin's configuration surface in sync with ruff's \`PyFormatOptions\`. Do NOT commit or push; only edit files in the working tree.`,
+    ``,
+    describeWiring(),
+    ``,
+    `To see exactly what changed in ruff, inspect the checked-out ruff source that cargo already downloaded (ruff is a git dependency), e.g.:`,
+    `  find ~/.cargo/git/checkouts -maxdepth 4 -type d -name 'ruff_python_formatter'`,
+    `then read the \`PyFormatOptions\` struct, its \`with_*\` builder methods, and the option enums in \`ruff_python_formatter\` (and shared types in \`ruff_formatter\`). Compare that against \`resolve_options\` in \`src/format_text.rs\`.`,
+    ``,
+    `Rules:`,
+    `1. If an option was RENAMED or REMOVED in \`PyFormatOptions\`, update the mapping in \`src/format_text.rs\` (and remove/rename the corresponding plugin config in the other files if it no longer exists upstream).`,
+    `2. If an option was ADDED in \`PyFormatOptions\`, expose it as a new plugin config option across ALL of: \`configuration.rs\`, \`resolve_config.rs\`, \`format_text.rs\`, and \`deployment/schema.json\`, AND add a spec test under \`tests/specs/\` that exercises it. Match the existing naming conventions (Rust snake_case fields, camelCase dprint keys).`,
+    `3. Do NOT edit \`README.md\`. Its config documentation is maintained separately, so leave it untouched.`,
+    `4. Preserve the existing code style. Keep non-test code above test modules. New comments start lowercase unless multiple sentences.`,
+    `5. When done, ALL of these must pass (CI denies clippy warnings, and the wasm build is what actually ships) — iterate until they are all clean:`,
+    `     cargo test`,
+    `     cargo clippy --all-targets --all-features -- -D warnings`,
+    `     cargo build --target wasm32-unknown-unknown --features wasm --release`,
+    `6. Do not change the plugin's own version in Cargo.toml, do not run git commit, and do not push.`,
+    ``,
+    `Spec test format: each file in \`tests/specs/\` has a \`~~ optionKey: value ~~\` config header line, then \`== short description ==\`, the input code, a line containing \`[expect]\`, and the expected formatted output. Add or update specs for options you add or rename (follow the existing files as examples and the \`Config<Name>.txt\` naming), delete the spec for any removed option, and run \`cargo test\` to confirm they pass.`,
+  ].join("\n");
+}
+
+function buildRefixPrompt(review: ReviewResult): string {
+  return [
+    `An independent reviewer examined your changes to dprint-plugin-ruff and found issues that must be fixed. Address every blocking issue below, keeping \`cargo test\` green. Do not commit or push.`,
+    ``,
+    `Reviewer summary: ${review.summary}`,
+    ``,
+    `Issues:`,
+    ...review.issues.map((i) => `  - [${i.severity}] ${i.description}`),
+    ``,
+    describeWiring(),
+  ].join("\n");
+}
+
+function describeWiring(): string {
+  return [
+    `How the plugin is wired (keep all of these consistent with each other):`,
+    `- \`src/format_text.rs\` -> \`resolve_options\` maps this plugin's \`Configuration\` onto ruff's \`PyFormatOptions\` (through its \`with_*\` builder methods) and the option enums (\`IndentStyle\`, \`LineEnding\`, \`QuoteStyle\`, \`MagicTrailingComma\`, \`PreviewMode\`).`,
+    `- \`src/configuration/configuration.rs\` -> the plugin's own \`Configuration\` struct and enums.`,
+    `- \`src/configuration/resolve_config.rs\` -> reads each dprint config key (camelCase) into \`Configuration\`.`,
+    `- \`deployment/schema.json\` -> the JSON schema of config options shown to users.`,
+    `- \`tests/specs/*.txt\` -> spec tests (run by \`dprint_development::run_specs\` via \`tests/test.rs\`) that exercise each config option.`,
+  ].join("\n");
+}
+
+// keep the tail of long check output -- the errors and the "could not compile"
+// summary are at the end, which is the most useful part for the AI.
+function truncateHead(text: string, max = 20_000): string {
+  return text.length > max ? `... (truncated)\n${text.slice(text.length - max)}` : text;
+}
+
+// stage 2: independent reviewer ------------------------------------------------
+
+interface ReviewResult {
+  approved: boolean;
+  summary: string;
+  issues: ReviewIssue[];
+}
+
+interface ReviewIssue {
+  severity: "blocking" | "nit";
+  description: string;
+}
+
+// The reviewer runs Codex too so it can actually investigate (read the ruff
+// source cargo downloaded, grep the repo, verify option names against the real
+// upstream API). Its verdict is captured as JSON via --output-last-message.
+//
+// NOTE: we deliberately do NOT use `--sandbox read-only` here. That makes Codex
+// wrap commands in bubblewrap, which cannot set up its network namespace on the
+// GitHub Actions runner ("bwrap: loopback: Failed RTM_NEWADDR: Operation not
+// permitted"), so every command the reviewer runs fails before executing. We
+// use the same no-sandbox mode as the fixer and enforce read-only via the
+// prompt instead. (CI is itself a throwaway VM, and the final check gate in
+// update.ts re-verifies whatever ends up in the working tree.)
+async function reviewChanges(options: AiFixOptions): Promise<ReviewResult> {
+  // default to a different model than the Codex fixer so the review is a
+  // genuinely independent second opinion.
+  const model = Deno.env.get("REVIEW_MODEL") ?? "gpt-5.6-sol";
+
+  // record intent-to-add so any files Codex created also show in `git diff`.
+  await $`git add -N .`.quiet();
+
+  const outputFile = await Deno.makeTempFile({ prefix: "codex-review-", suffix: ".json" });
+  try {
+    $.logStep(`Reviewing changes with Codex (${model})...`);
+    const args = [
+      "exec",
+      "--skip-git-repo-check",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--model",
+      model,
+      "--output-last-message",
+      outputFile,
+      buildReviewPrompt(options),
+    ];
+    await $`codex ${args}`;
+    return parseReview(await Deno.readTextFile(outputFile));
+  } finally {
+    await Deno.remove(outputFile).catch(() => {});
+  }
+}
+
+function buildReviewPrompt(options: AiFixOptions): string {
+  return [
+    `You are an independent reviewer for dprint-plugin-ruff, a dprint plugin that wraps ruff's Python formatter to format Python. Ruff was just upgraded from ${options.fromVersion} to ${options.toVersion} and another AI edited this plugin to reconcile it. Review the UNCOMMITTED working-tree changes.`,
+    `IMPORTANT: this is REVIEW ONLY. Read any files and run read-only commands (git diff, cat, grep, find, etc.) to investigate, but you MUST NOT edit, create, or delete any files, and MUST NOT run git commit or git push. Leave the working tree exactly as you found it.`,
+    ``,
+    `Investigate as needed:`,
+    `- Run \`git --no-pager diff\` (and \`git status\`) to see exactly what changed, including any new files.`,
+    `- Verify against the REAL ruff ${options.toVersion} API by reading the source cargo downloaded (ruff is a git dependency):`,
+    `    find ~/.cargo/git/checkouts -maxdepth 4 -type d -name 'ruff_python_formatter'`,
+    `  then read the \`PyFormatOptions\` struct, its \`with_*\` methods, and the option enums in \`ruff_python_formatter\` and \`ruff_formatter\`.`,
+    `- Read the plugin files to confirm they are consistent with each other and with upstream.`,
+    ``,
+    describeWiring(),
+    ``,
+    `Verify specifically:`,
+    `- Every \`with_*\` option set in \`resolve_options\` still exists on ruff's \`PyFormatOptions\` with that exact name (catch removed/renamed options).`,
+    `- Any formatter option newly added upstream is exposed through ALL layers: configuration.rs, resolve_config.rs, format_text.rs, and deployment/schema.json. A partial addition is a blocking issue.`,
+    `- Every config option added or renamed in this change has a spec test under \`tests/specs/\` exercising it (and any removed option's spec is deleted). A missing spec test is a blocking issue.`,
+    `- Naming conventions are consistent (Rust snake_case fields, camelCase dprint keys, matching the schema).`,
+    `- README.md was NOT modified (its documentation is maintained separately); flag any README.md change as a blocking issue.`,
+    `- No obvious correctness bugs, and code style matches the surrounding code.`,
+    ``,
+    `When done, your FINAL message must be ONLY a JSON object (no markdown code fences, no extra prose) of exactly this shape:`,
+    `{"approved": true|false, "summary": "one sentence", "issues": [{"severity": "blocking"|"nit", "description": "..."}]}`,
+    `Set approved=false if there is any blocking issue; nits alone do not block.`,
+  ].join("\n");
+}
+
+function parseReview(message: string): ReviewResult {
+  const review = JSON.parse(extractJsonObject(message)) as ReviewResult;
+  if (typeof review.approved !== "boolean" || !Array.isArray(review.issues)) {
+    throw new Error(`Codex review returned malformed JSON:\n${message}`);
+  }
+  return review;
+}
+
+// Codex is instructed to emit only JSON, but tolerate an accidental code fence
+// or surrounding prose by extracting the outermost { ... } object.
+function extractJsonObject(text: string): string {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`Could not find a JSON object in Codex review output:\n${text}`);
+  }
+  return text.slice(start, end + 1);
+}
+
+function logReview(review: ReviewResult): void {
+  $.log(`Review: ${review.approved ? "approved" : "changes requested"} — ${review.summary}`);
+  for (const issue of review.issues) {
+    $.logLight(`  [${issue.severity}] ${issue.description}`);
+  }
+}
+
+// setup ------------------------------------------------------------------------
+
+function requireApiKey(): string {
+  const apiKey = Deno.env.get("OPENAI_API_KEY");
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set. It is required to run the AI fixer and reviewer.");
+  }
+  return apiKey;
+}
+
+async function ensureCodexInstalled(): Promise<void> {
+  const found = await $`codex --version`.noThrow().quiet();
+  if (found.code === 0) {
+    return;
+  }
+  $.logStep("Installing OpenAI Codex CLI...");
+  await $`npm install -g @openai/codex`;
+}
+
+// `codex exec` does not read OPENAI_API_KEY on its own -- it needs credentials
+// stored via `codex login` first, otherwise its requests go out with no auth
+// header and the API returns 401. The key is piped over stdin so it never
+// appears in the process arguments.
+async function codexLogin(apiKey: string): Promise<void> {
+  $.logStep("Authenticating Codex with the OpenAI API key...");
+  await $`codex login --with-api-key`.stdinText(apiKey);
+}

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -4,6 +4,7 @@
  */
 import { $, CargoToml, semver } from "automation";
 import { Octokit } from "octokit";
+import { aiFixRuffUpdate } from "./ai_fix.ts";
 
 const rootDirPath = $.path(import.meta.dirname!).parentOrThrow();
 const cargoToml = new CargoToml(rootDirPath.join("Cargo.toml"));
@@ -30,9 +31,33 @@ const isPatchBump = cargoTomlVersion.version.major === latestTag.version.major
   && cargoTomlVersion.version.minor === latestTag.version.minor;
 cargoToml.replaceAll(cargoTomlVersion.tag, latestTag.tag);
 
-// run the tests
-$.logStep("Running tests...");
-await $`cargo test`;
+// Verify the update. A clean patch bump publishes exactly as before. A minor
+// bump always gets an AI review (Ruff may have added options without breaking
+// the build), and a patch bump that fails the checks gets an AI fix attempt.
+$.logStep("Running checks (test + clippy + wasm build)...");
+const checks = await runChecks();
+
+if (!isPatchBump || !checks.passed) {
+  if (checks.passed) {
+    $.logStep("Minor Ruff update — running AI review for new/changed options...");
+  } else {
+    $.logStep("Patch update failed the checks — running AI fix...");
+  }
+  await aiFixRuffUpdate({
+    isPatchBump,
+    fromVersion: cargoTomlVersion.tag,
+    toVersion: latestTag.tag,
+    checksPassed: checks.passed,
+    // hand the failing output to the AI so it can go straight to fixing
+    // instead of re-running the checks just to rediscover the errors.
+    checkOutput: checks.output,
+  });
+
+  // the AI must leave the project in a passing state, otherwise fail the
+  // workflow (nothing gets published and the maintainer is notified).
+  $.logStep("Re-running checks after AI changes...");
+  await assertChecks();
+}
 
 if (Deno.args.includes("--skip-publish")) {
   Deno.exit(0);
@@ -44,16 +69,63 @@ const message = `${isPatchBump ? "fix" : "feat"}: update to Ruff ${latestTag.tag
 await $`git commit -m ${message}`;
 
 $.logStep("Bumping version in Cargo.toml...");
-cargoToml.bumpCargoTomlVersion(isPatchBump ? "patch" : "minor");
+// reload from disk before bumping: the AI may have edited Cargo.toml (e.g.
+// adding a new ruff crate dependency), and the in-memory copy loaded at startup
+// is stale. Writing the stale copy here would clobber those edits.
+const releaseCargoToml = new CargoToml(rootDirPath.join("Cargo.toml"));
+releaseCargoToml.bumpCargoTomlVersion(isPatchBump ? "patch" : "minor");
 
 // release
-const newVersion = cargoToml.version();
+const newVersion = releaseCargoToml.version();
 $.logStep(`Committing and publishing ${newVersion}...`);
 await $`git add .`;
 await $`git commit -m ${newVersion}`;
 await $`git push origin main`;
 await $`git tag ${newVersion}`;
 await $`git push origin ${newVersion}`;
+
+// the checks that must pass before publishing. clippy is included because
+// Codex runs it with warnings denied, so a clippy warning is as breaking as a
+// test failure, and the wasm release build is included because that is what
+// actually ships. `inheritPiped` + `captureCombined` streams the output to the
+// CI log live while also capturing it so a failure can be handed to the AI.
+async function runChecks(): Promise<{ passed: boolean; output: string }> {
+  const results = [];
+  for (const command of checkCommands()) {
+    results.push(await capture(command()));
+  }
+  const failures = results.filter((r) => r.code !== 0);
+  return {
+    passed: failures.length === 0,
+    output: failures.map((r) => r.combined).join("\n\n"),
+  };
+}
+
+function capture(command: ReturnType<typeof $>) {
+  return command
+    .stdout("inheritPiped")
+    .stderr("inheritPiped")
+    .captureCombined()
+    .noThrow();
+}
+
+// same checks as `runChecks`, but throws on the first failure so the workflow
+// aborts before anything is committed, tagged, or published.
+async function assertChecks(): Promise<void> {
+  for (const command of checkCommands()) {
+    await command();
+  }
+}
+
+// a function (not a top-level const) so it is hoisted -- `runChecks` is called
+// from top-level code above before a const declared here would be initialized.
+function checkCommands() {
+  return [
+    () => $`cargo test`,
+    () => $`cargo clippy --all-targets --all-features -- -D warnings`,
+    () => $`cargo build --target wasm32-unknown-unknown --features wasm --release`,
+  ];
+}
 
 function getRuffCargoTomlTag(text: string) {
   const match = text.match(/git = \"https:\/\/github.com\/astral-sh\/ruff\", tag = \"([^\"]+)\"/);


### PR DESCRIPTION
Ports the AI update pipeline (already on dprint-plugin-mago / biome / oxc) to this repo. When the daily `check_updates` job bumps the Ruff tag, breaking changes can be reconciled automatically instead of just failing.

## Flow (`scripts/update.ts`)
After applying the new Ruff tag:

| Case | Behavior |
|---|---|
| Patch, checks pass | Publishes exactly as before — no AI |
| Patch, checks fail | AI fixer → reviewer → re-run checks → publish |
| Minor (always) | AI reviewer/fixer (Ruff may add options without breaking the build) → re-run checks → publish |

**Checks** = `cargo test` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo build --target wasm32-unknown-unknown --features wasm --release`. Combined output is captured (streamed live via `inheritPiped`) and handed to the fixer.

## AI (`scripts/ai_fix.ts`)
1. **Fixer** — a Codex `exec` session reads the checked-out ruff source under `~/.cargo/git/checkouts`, wires new/renamed/removed `PyFormatOptions` through `configuration.rs`, `resolve_config.rs`, `format_text.rs`, `deployment/schema.json`, **and adds spec tests under `tests/specs/`**, iterating until all checks pass. Model: `CODEX_MODEL` (`gpt-5.6-terra`).
2. **Reviewer** — a *separate* model (`REVIEW_MODEL`, `gpt-5.6-sol`) reviews the diff via Codex, investigating upstream, and returns a structured verdict; a missing spec test is a blocking issue. Not approved → throws, nothing publishes.

Includes all the fixes made on the other repos: `codex login --with-api-key`, reviewer runs without the bubblewrap sandbox (fails on GH runners) and is prompt-enforced read-only, `Cargo.toml` reloaded before the version bump, hoisted `checkCommands()` (no TDZ bug), README left untouched.

## Before relying on it
- [x] Add the **`OPENAI_API_KEY`** repo secret.
- [x] Confirm the model IDs against a real breaking Ruff release (verified type-check/lint/generation only).