### PR TITLE
chore: use npm plugin specifiers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="unsupported"']
+rustflags = ["--cfg", 'getrandom_backend="unsupported"']

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Then in your project's directory with a dprint.json file, run:
 
 ```shellsession
 dprint add ruff
-# or install from npm
-dprint add npm:@dprint/ruff
 ```
 
 ## Configuration

--- a/dprint.json
+++ b/dprint.json
@@ -12,10 +12,10 @@
     "**/target"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.88.3.wasm",
-    "https://plugins.dprint.dev/json-0.19.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.16.2.wasm",
-    "https://plugins.dprint.dev/toml-0.5.4.wasm",
-    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7"
+    "npm:@dprint/typescript@0.96.1",
+    "npm:@dprint/json@0.23.0",
+    "npm:@dprint/markdown@0.22.1",
+    "npm:@dprint/toml@0.8.0",
+    "npm:@dprint/exec@0.7.3/plugin.json@704701df449dd7e942a71144773778ac529d68c2e4657bfc236d393b898b9a67"
   ]
 }

--- a/scripts/ai_fix.ts
+++ b/scripts/ai_fix.ts
@@ -55,8 +55,8 @@ export async function aiFixRuffUpdate(options: AiFixOptions): Promise<void> {
     if (round > REVIEW_MAX_ROUNDS) {
       const blocking = review.issues.filter((i) => i.severity === "blocking");
       throw new Error(
-        `AI reviewer did not approve after ${REVIEW_MAX_ROUNDS} refix round(s). Blocking issues:\n` +
-          blocking.map((i) => `  - ${i.description}`).join("\n"),
+        `AI reviewer did not approve after ${REVIEW_MAX_ROUNDS} refix round(s). Blocking issues:\n`
+          + blocking.map((i) => `  - ${i.description}`).join("\n"),
       );
     }
     $.logStep(`Reviewer requested changes — Codex refix round ${round}...`);


### PR DESCRIPTION
`dprint add <plugin>` now outputs npm specifiers, so update the config file and install instructions to match.
