### PR TITLE
fix(BREAKING): upgrade to dprint-core 0.69.1 and Wasm plugins v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dprint-core"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
+checksum = "67359cea061dd052fca921d3589a9ce59bc16fa23bfb9d06d5c669a1dbd23915"
 dependencies = [
  "indexmap",
  "serde",
@@ -1470,22 +1470,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,13 +362,14 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dprint-core"
-version = "0.63.3"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7227b28d24aafee21ff72512336c797fa00bb3ea803186b1b105a68abc97660b"
+checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
 dependencies = [
- "anyhow",
  "indexmap",
  "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -385,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-ruff"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "dprint-core",
@@ -1469,22 +1470,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.20"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.20"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
 anyhow = "1.0.51"
-dprint-core = { version = "0.63.3", default-features = false }
+dprint-core = { version = "0.69.0", default-features = false }
 get-size2 = "=0.10.3"
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.16.4" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.16.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
 anyhow = "1.0.51"
-dprint-core = { version = "0.69.0", default-features = false }
+dprint-core = { version = "0.69.1", default-features = false }
 get-size2 = "=0.10.3"
 ruff_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.16.4" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.16.4" }

--- a/deployment/npm/index.test.js
+++ b/deployment/npm/index.test.js
@@ -4,6 +4,9 @@ const createFromBuffer = require("@dprint/formatter").createFromBuffer;
 const getBuffer = require("./index").getBuffer;
 
 const formatter = createFromBuffer(getBuffer());
-const result = formatter.formatText("file.py", `print(   "Hi"   )`);
+const result = formatter.formatText({
+  filePath: "file.py",
+  fileText: `print(   "Hi"   )`,
+});
 
 assert.strictEqual(result, `print("Hi")\n`);

--- a/deployment/npm/package-lock.json
+++ b/deployment/npm/package-lock.json
@@ -1,14 +1,23 @@
 {
   "name": "@dprint/ruff",
   "version": "0.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@dprint/formatter": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@dprint/formatter/-/formatter-0.1.4.tgz",
-      "integrity": "sha512-L7PifpVn+u1fH+5jUNv6W2Ie5LYvG5rlXCB9hn/byozAj1WOjaZczwvWmYWNS2zObF3d+PjKf6ON+HCPHjqNvQ==",
-      "dev": true
+  "packages": {
+    "": {
+      "name": "@dprint/ruff",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@dprint/formatter": "~0.4.0"
+      }
+    },
+    "node_modules/@dprint/formatter": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@dprint/formatter/-/formatter-0.4.1.tgz",
+      "integrity": "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/deployment/npm/package.json
+++ b/deployment/npm/package.json
@@ -24,6 +24,6 @@
     "test": "node index.test.js"
   },
   "devDependencies": {
-    "@dprint/formatter": "~0.1.4"
+    "@dprint/formatter": "~0.4.0"
   }
 }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -41,7 +41,7 @@ pub fn resolve_config(
     line_ending: get_nullable_value(&mut config, "lineEnding", &mut diagnostics).or(global_config.new_line_kind.map(
       |l| match l {
         // not ideal
-        NewLineKind::Auto | NewLineKind::LineFeed | NewLineKind::System => LineEnding::LineFeed,
+        NewLineKind::Auto | NewLineKind::LineFeed => LineEnding::LineFeed,
         NewLineKind::CarriageReturnLineFeed => LineEnding::CarriageReturnLineFeed,
       },
     )),

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -1,13 +1,17 @@
 use super::configuration::{resolve_config, Configuration};
 
-use dprint_core::configuration::{ConfigKeyMap, GlobalConfiguration, ResolveConfigurationResult};
+use dprint_core::configuration::{ConfigKeyMap, GlobalConfiguration};
 use dprint_core::generate_plugin_code;
+use dprint_core::plugins::CheckConfigUpdatesMessage;
+use dprint_core::plugins::ConfigChange;
 use dprint_core::plugins::FileMatchingInfo;
+use dprint_core::plugins::FormatError;
 use dprint_core::plugins::FormatResult;
 use dprint_core::plugins::PluginInfo;
+use dprint_core::plugins::PluginResolveConfigurationResult;
+use dprint_core::plugins::SyncFormatRequest;
+use dprint_core::plugins::SyncHostFormatRequest;
 use dprint_core::plugins::SyncPluginHandler;
-use dprint_core::plugins::SyncPluginInfo;
-use std::path::Path;
 
 struct RuffPluginHandler;
 
@@ -16,24 +20,11 @@ impl SyncPluginHandler<Configuration> for RuffPluginHandler {
     &mut self,
     config: ConfigKeyMap,
     global_config: &GlobalConfiguration,
-  ) -> ResolveConfigurationResult<Configuration> {
-    resolve_config(config, global_config)
-  }
-
-  fn plugin_info(&mut self) -> SyncPluginInfo {
-    let version = env!("CARGO_PKG_VERSION").to_string();
-    SyncPluginInfo {
-      info: PluginInfo {
-        name: env!("CARGO_PKG_NAME").to_string(),
-        version: version.clone(),
-        config_key: "ruff".to_string(),
-        help_url: "https://dprint.dev/plugins/ruff".to_string(),
-        config_schema_url: format!(
-          "https://plugins.dprint.dev/dprint/dprint-plugin-ruff/{}/schema.json",
-          version
-        ),
-        update_url: Some("https://plugins.dprint.dev/dprint/dprint-plugin-ruff/latest.json".to_string()),
-      },
+  ) -> PluginResolveConfigurationResult<Configuration> {
+    let result = resolve_config(config, global_config);
+    PluginResolveConfigurationResult {
+      config: result.config,
+      diagnostics: result.diagnostics,
       file_matching: FileMatchingInfo {
         file_extensions: vec![
           "py".to_string(),
@@ -46,18 +37,42 @@ impl SyncPluginHandler<Configuration> for RuffPluginHandler {
     }
   }
 
+  fn plugin_info(&mut self) -> PluginInfo {
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    PluginInfo {
+      name: env!("CARGO_PKG_NAME").to_string(),
+      version: version.clone(),
+      config_key: "ruff".to_string(),
+      help_url: "https://dprint.dev/plugins/ruff".to_string(),
+      config_schema_url: format!(
+        "https://plugins.dprint.dev/dprint/dprint-plugin-ruff/{}/schema.json",
+        version
+      ),
+      update_url: Some("https://plugins.dprint.dev/dprint/dprint-plugin-ruff/latest.json".to_string()),
+    }
+  }
+
   fn license_text(&mut self) -> String {
     std::str::from_utf8(include_bytes!("../LICENSE")).unwrap().into()
   }
 
+  fn check_config_updates(&self, _message: CheckConfigUpdatesMessage) -> Result<Vec<ConfigChange>, FormatError> {
+    Ok(Vec::new())
+  }
+
   fn format(
     &mut self,
-    file_path: &Path,
-    file_text: &str,
-    config: &Configuration,
-    _format_with_host: impl FnMut(&Path, String, &ConfigKeyMap) -> FormatResult,
+    request: SyncFormatRequest<Configuration>,
+    _format_with_host: impl FnMut(SyncHostFormatRequest) -> FormatResult,
   ) -> FormatResult {
-    super::format_text(file_path, file_text, config)
+    if request.range.is_some() {
+      return Ok(None); // not supported
+    }
+
+    let file_text = String::from_utf8(request.file_bytes).map_err(FormatError::new)?;
+    super::format_text(request.file_path, &file_text, request.config)
+      .map(|maybe_text| maybe_text.map(|t| t.into_bytes()))
+      .map_err(FormatError::new)
   }
 }
 


### PR DESCRIPTION
Upgrades `dprint-core` from 0.63.3 to 0.69.0.

This jump crosses the "Wasm plugins v4" rework (0.67.0) and the `anyhow` removal (0.68.0), so `src/wasm_plugin.rs` needed a real migration rather than just a version bump.

## Source changes

**`src/wasm_plugin.rs`** — migrated to the v4 `SyncPluginHandler` interface:

- `resolve_config` now returns `PluginResolveConfigurationResult<Configuration>`. `FileMatchingInfo` (the `py`/`pyi` extensions) moved here from `plugin_info`.
- `plugin_info` now returns `PluginInfo` directly — `SyncPluginInfo` no longer exists.
- Added the now-required `check_config_updates`, returning `Ok(Vec::new())` (no config migrations for this plugin), with the new `Result<Vec<ConfigChange>, FormatError>` signature.
- `format` now takes a `SyncFormatRequest` / `SyncHostFormatRequest` and works in bytes rather than `&str`:
  - `request.file_bytes` is decoded with `String::from_utf8`.
  - the result is mapped back to `Vec<u8>`.
  - `request.range.is_some()` returns `Ok(None)` — this plugin never supported range formatting (the old interface had no range parameter), so this preserves the previous behavior.
  - `super::format_text(..)` is now `.map_err(FormatError::new)`, since `?` no longer converts an `anyhow::Error` into the core error type.

**`src/configuration/resolve_config.rs`** — `NewLineKind::System` was removed from dprint-core. It was already mapped to `LineEnding::LineFeed` in the same match arm as `Auto`/`LineFeed`, so dropping it is behavior-preserving.

**`deployment/npm/`** — the published Wasm module is now schema version 4, which `@dprint/formatter` 0.1.4 cannot load (`TypeError: get_plugin_schema_version is not a function`). Bumped to `~0.4.0` and switched `index.test.js` to the object-form `formatText({ filePath, fileText })` API, matching dprint-plugin-json / markdown / typescript / oxc. Verified by building the release Wasm and running the npm test against it.

`anyhow` is kept as a direct dependency: `format_text`'s public signature (`anyhow::Result<Option<String>>`) is unchanged, so this is not a breaking change for library consumers.

## Verification

- `cargo check` — passes
- `cargo check --target wasm32-unknown-unknown --features wasm` — passes
- `cargo test` — 4 passed, 0 failed (1 unit, 2 integration, 1 doc test); no test expectations were changed
- `cargo build --target wasm32-unknown-unknown --features wasm --release` + `cd deployment/npm && npm install && node setup.js && npm run test` — passes
- `dprint fmt --excludes "**/*.rs"` — no changes (rustfmt could not be run in the environment this was prepared in; `src/wasm_plugin.rs` was hand-formatted to match the surrounding style)

Note: `Cargo.lock` downgrades `thiserror` 2.0.20 -> 2.0.18 because dprint-core 0.69.0 pins `thiserror = "=2.0.18"`.
